### PR TITLE
Feature/decompose getdevices and getdevice

### DIFF
--- a/Photon-Tinker/DeviceEventTableViewCell.swift
+++ b/Photon-Tinker/DeviceEventTableViewCell.swift
@@ -57,7 +57,7 @@ class DeviceEventTableViewCell: DeviceDataTableViewCell {
         if let e = event {
             UIPasteboard.general.string = e.description
             RMessage.showNotification(withTitle: "Copied", subtitle: "Event payload was copied to the clipboard", type: .success, customTypeName: nil, callback: nil)
-            SEGAnalytics.shared().track("Device Inspector: event copied")
+            SEGAnalytics.shared().track("DeviceInspector_EventCopied")
         }
     }
 }

--- a/Photon-Tinker/DeviceFunctionTableViewCell.swift
+++ b/Photon-Tinker/DeviceFunctionTableViewCell.swift
@@ -32,7 +32,7 @@ internal class DeviceFunctionTableViewCell: DeviceDataTableViewCell, UITextField
     @IBOutlet weak var noFunctionsLabel: UILabel!
     @IBAction func callButtonTapped(_ sender: AnyObject) {
         var args = [String]()
-        SEGAnalytics.shared().track("Device Inspector: function called")
+        SEGAnalytics.shared().track("DeviceInspector_FunctionCalled")
         args.append(self.argumentsTextField.text!)
         self.resultLabel.isHidden = true
         self.activityIndicator.startAnimating()

--- a/Photon-Tinker/DeviceInspectorChildViewController.swift
+++ b/Photon-Tinker/DeviceInspectorChildViewController.swift
@@ -10,11 +10,7 @@
 
 class DeviceInspectorChildViewController: UIViewController {
 
-    var device : ParticleDevice? {
-        didSet {
-            ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Device set: %@ for instance: %@", withParameters: getVaList(["\(device)", String(describing: self)]))
-        }
-    }
+    var device : ParticleDevice?
     
     func showTutorial() {
         assert(false, "This method must be overriden by the DeviceInspectorChildViewController subclass")

--- a/Photon-Tinker/DeviceInspectorDataViewController.swift
+++ b/Photon-Tinker/DeviceInspectorDataViewController.swift
@@ -198,7 +198,7 @@ class DeviceInspectorDataViewController: DeviceInspectorChildViewController, UIT
             
             UIPasteboard.general.string = value
             RMessage.showNotification(withTitle: "Copied", subtitle: "Variable value was copied to the clipboard", type: .success, customTypeName: nil, callback: nil)
-            SEGAnalytics.shared().track("Device Inspector: variable copied")
+            SEGAnalytics.shared().track("DeviceInspector_VariableCopied")
         }
         
         

--- a/Photon-Tinker/DeviceInspectorDataViewController.swift
+++ b/Photon-Tinker/DeviceInspectorDataViewController.swift
@@ -34,7 +34,6 @@ class DeviceInspectorDataViewController: DeviceInspectorChildViewController, UIT
 
         for i in 0..<self.tableView(self.deviceDataTableView, numberOfRowsInSection: 1) {
             index = IndexPath(row: i, section: 1)
-            ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Thread %@", withParameters: getVaList([Thread.current]))
             let cell: DeviceVariableTableViewCell? = self.deviceDataTableView.cellForRow(at: index) as? DeviceVariableTableViewCell
 
             if let c = cell {
@@ -145,9 +144,6 @@ class DeviceInspectorDataViewController: DeviceInspectorChildViewController, UIT
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-
-        ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Thread %@", withParameters: getVaList([Thread.current]))
-
         var masterCell : UITableViewCell?
         
         switch (indexPath as NSIndexPath).section {
@@ -161,9 +157,7 @@ class DeviceInspectorDataViewController: DeviceInspectorChildViewController, UIT
                 cell!.functionName = self.device?.functions[(indexPath as NSIndexPath).row]
                 cell!.device = self.device
             }
-            
-            //            cell?.centerFunctionNameLayoutConstraint.constant = selected ? 0 : -20
-            
+
             masterCell = cell
             
         default :

--- a/Photon-Tinker/DeviceInspectorEventsViewController.swift
+++ b/Photon-Tinker/DeviceInspectorEventsViewController.swift
@@ -162,7 +162,7 @@ class DeviceInspectorEventsViewController: DeviceInspectorChildViewController, U
         
         self.filterText = searchText
         self.filterEvents()
-        SEGAnalytics.shared().track("Device Inspector: event filter typing")
+        SEGAnalytics.shared().track("DeviceInspector_EventFilterTyping")
         DispatchQueue.main.async {
             self.deviceEventsTableView.reloadData()
         }
@@ -182,12 +182,12 @@ class DeviceInspectorEventsViewController: DeviceInspectorChildViewController, U
 @IBAction func playPauseButtonTapped(_ sender: AnyObject) {
         if paused {
             paused = false
-            SEGAnalytics.shared().track("Device Inspector: event stream play")
+            SEGAnalytics.shared().track("DeviceInspector_EventStreamPlay")
             playPauseButton.setImage(UIImage(named: "imgPause"), for: UIControlState())
             subscribeToDeviceEvents()
         } else {
             paused = true
-            SEGAnalytics.shared().track("Device Inspector: event stream pause")
+            SEGAnalytics.shared().track("DeviceInspector_EventStreamPause")
             playPauseButton.setImage(UIImage(named: "imgPlay"), for: UIControlState())
             unsubscribeFromDeviceEvents()
         }
@@ -206,7 +206,7 @@ class DeviceInspectorEventsViewController: DeviceInspectorChildViewController, U
                                     self.filteredEvents = nil
                                     self.deviceEventsTableView.reloadData()
                                     self.noEventsLabel.isHidden = false
-                                    SEGAnalytics.shared().track("Device Inspector: events cleared")
+                                    SEGAnalytics.shared().track("DeviceInspector_EventsCleared")
 
             }
         )

--- a/Photon-Tinker/DeviceInspectorInfoViewController.swift
+++ b/Photon-Tinker/DeviceInspectorInfoViewController.swift
@@ -27,13 +27,13 @@ class DeviceInspectorInfoViewController: DeviceInspectorChildViewController {
     @IBAction func copyDeviceIdButtonTapped(_ sender: AnyObject) {
         UIPasteboard.general.string = self.device?.id
         RMessage.showNotification(withTitle: "Copied", subtitle: "Device ID was copied to the clipboard", type: .success, customTypeName: nil, callback: nil)
-        SEGAnalytics.shared().track("Device Inspector: device ID copied")
+        SEGAnalytics.shared().track("DeviceInspector_DeviceIDCopied")
     }
     
     @IBAction func copyDeviceIccidButtonTapped(_ sender: UIButton) {
         UIPasteboard.general.string = self.device?.lastIccid
         RMessage.showNotification(withTitle: "Copied", subtitle: "Device SIM ICCID was copied to the clipboard", type: .success, customTypeName: nil, callback: nil)
-        SEGAnalytics.shared().track("Device Inspector: device ICCID copied")
+        SEGAnalytics.shared().track("DeviceInspector_DeviceICCIDCopied")
     }
     
     

--- a/Photon-Tinker/DeviceInspectorViewController.swift
+++ b/Photon-Tinker/DeviceInspectorViewController.swift
@@ -284,9 +284,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
     
     func refreshData() {
         self.device.refresh({[weak self] (err: Error?) in
-            
             SEGAnalytics.shared().track("Device Inspector: refreshed data")
-
 
             if (err == nil) {
                 if let s = self {

--- a/Photon-Tinker/DeviceInspectorViewController.swift
+++ b/Photon-Tinker/DeviceInspectorViewController.swift
@@ -173,7 +173,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
         if (sender.selectedSegmentIndex == 0) // info
         {
             self.infoVC!.showTutorial()
-            SEGAnalytics.shared().track("Device Inspector: info view")
+            SEGAnalytics.shared().track("DeviceInspector_InfoView")
         }
         
         if (sender.selectedSegmentIndex == 1) // functions and variables
@@ -181,13 +181,13 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
             self.dataVC!.refreshVariableList()
             self.dataVC!.showTutorial()
             self.dataVC!.readAllVariablesOnce()
-            SEGAnalytics.shared().track("Device Inspector: data view")
+            SEGAnalytics.shared().track("DeviceInspector_DataView")
         }
         
         if (sender.selectedSegmentIndex == 2) // events
         {
             self.eventsVC!.showTutorial()
-            SEGAnalytics.shared().track("Device Inspector: events view")
+            SEGAnalytics.shared().track("DeviceInspector_EventsView")
         }
  
         
@@ -197,7 +197,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
 
     override func viewDidLoad() {
 
-        SEGAnalytics.shared().track("Device Inspector: started")
+        SEGAnalytics.shared().track("DeviceInspector_Started")
        
         let font = UIFont(name: "Gotham-book", size: 15.0)
         
@@ -269,7 +269,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
     func particleDevice(_ device: ParticleDevice, didReceive event: ParticleDeviceSystemEvent) {
         ParticleUtils.animateOnlineIndicatorImageView(self.deviceOnlineIndicatorImageView, online: self.device.connected, flashing: self.device.isFlashing)
         if self.flashedTinker && event == .flashSucceeded {
-            SEGAnalytics.shared().track("Device Inspector: reflash Tinker success")
+            SEGAnalytics.shared().track("DeviceInspector_ReflashTinkerSuccess")
             DispatchQueue.main.async {
                 RMessage.showNotification(withTitle: "Flashing successful", subtitle: "Your device has been flashed with Tinker firmware successfully", type: .success, customTypeName: nil, callback: nil)
             }
@@ -284,7 +284,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
     
     func refreshData() {
         self.device.refresh({[weak self] (err: Error?) in
-            SEGAnalytics.shared().track("Device Inspector: refreshed data")
+            SEGAnalytics.shared().track("DeviceInspector_RefreshedData")
 
             if (err == nil) {
                 if let s = self {
@@ -317,7 +317,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
     
     // 2
     func reflashTinker() {
-        SEGAnalytics.shared().track("Device Inspector: reflash Tinker start")
+        SEGAnalytics.shared().track("DeviceInspector_ReflashTinkerStart")
         
         func flashTinkerBinary(_ binaryFilename : String?)
         {
@@ -343,7 +343,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
         {
         case .core:
             //                                        SEGAnalytics.sharedAnalytics().track("Tinker: Reflash Tinker",
-            SEGAnalytics.shared().track("Tinker: Reflash Tinker", properties: ["device":"Core"])
+            SEGAnalytics.shared().track("Tinker_ReflashTinker", properties: ["device":"Core"])
             self.flashedTinker = true
             self.device.flashKnownApp("tinker", completion: { (error:Error?) -> Void in
                 if let e=error
@@ -353,11 +353,11 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
             })
             
         case .photon:
-            SEGAnalytics.shared().track("Tinker: Reflash Tinker", properties: ["device":"Photon"])
+            SEGAnalytics.shared().track("Tinker_ReflashTinker", properties: ["device":"Photon"])
             flashTinkerBinary("photon-tinker")
             
         case .electron:
-            SEGAnalytics.shared().track("Tinker: Reflash Tinker", properties: ["device":"Electron"])
+            SEGAnalytics.shared().track("Tinker_ReflashTinker", properties: ["device":"Electron"])
             
             let dialog = ZAlertView(title: "Flashing Electron", message: "Flashing Tinker to Electron via cellular will consume data from your data plan, are you sure you want to continue?", isOkButtonLeft: true, okButtonText: "No", cancelButtonText: "Yes",
                                     okButtonHandler: { alertView in
@@ -386,7 +386,7 @@ class DeviceInspectorViewController : UIViewController, UITextFieldDelegate, Par
     
     func popDocumentationViewController() {
 
-        SEGAnalytics.shared().track("Device Inspector: documentation")
+        SEGAnalytics.shared().track("DeviceInspector_DocumentationOpened")
         self.performSegue(withIdentifier: "help", sender: self)
 //        let storyboard : UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
 //        let vc : UIViewController = storyboard.instantiateViewControllerWithIdentifier("help")

--- a/Photon-Tinker/DeviceListViewController.swift
+++ b/Photon-Tinker/DeviceListViewController.swift
@@ -166,11 +166,11 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
         if segue.identifier == "deviceInspector" {
             if let vc = segue.destination as? DeviceInspectorViewController {
                 let indexPath = sender as! IndexPath
-                vc.device = self.devices[indexPath.row]
+                vc.setup(device: self.devices[indexPath.row])
 
                 let deviceInfo = ParticleUtils.getDeviceTypeAndImage(self.devices[indexPath.row])
 
-                ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Segue into device inspector - idx: %i device: %@", withParameters: getVaList([indexPath.row, "\(vc.device)"]))
+                ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Segue into device inspector - idx: %i device: %@", withParameters: getVaList([indexPath.row, "\(self.devices[indexPath.row])"]))
 
                 SEGAnalytics.shared().track("Tinker: Device Inspector", properties: ["device":deviceInfo.deviceType])
                 

--- a/Photon-Tinker/DeviceListViewController.swift
+++ b/Photon-Tinker/DeviceListViewController.swift
@@ -140,7 +140,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
     }
     
     func invokeElectronSetup() {
-        SEGAnalytics.shared().track("Tinker: Electron setup invoked")
+        SEGAnalytics.shared().track("Tinker_ElectronSetupInvoked")
         let esVC : ElectronSetupViewController = self.storyboard!.instantiateViewController(withIdentifier: "electronSetup") as! ElectronSetupViewController
         self.present(esVC, animated: true, completion: nil)
         
@@ -158,7 +158,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
 
                 ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Segue into tinker - idx: %i device: %@", withParameters: getVaList([indexPath.row, vc.device.description]))
 
-                SEGAnalytics.shared().track("Tinker: Start Tinkering", properties: ["device":deviceInfo.deviceType, "running_tinker":vc.device.isRunningTinker()])
+                SEGAnalytics.shared().track("Tinker_SegueToTinker", properties: ["device":deviceInfo.deviceType, "running_tinker":vc.device.isRunningTinker()])
                 
             }
         }
@@ -172,7 +172,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
 
                 ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Segue into device inspector - idx: %i device: %@", withParameters: getVaList([indexPath.row, "\(self.devices[indexPath.row])"]))
 
-                SEGAnalytics.shared().track("Tinker: Device Inspector", properties: ["device":deviceInfo.deviceType])
+                SEGAnalytics.shared().track("Tinker_SegueToDeviceInspector", properties: ["device":deviceInfo.deviceType])
                 
             }
         }
@@ -205,7 +205,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
             */
         }
 
-        SEGAnalytics.shared().track("Tinker: Device list screen activity")
+        SEGAnalytics.shared().track("Tinker_DeviceListScreenActivity")
         NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive(_:)), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
 
@@ -548,7 +548,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
         if result == .success
         {
             ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Photon setup ended", withParameters: getVaList([]))
-            SEGAnalytics.shared().track("Tinker: Photon setup ended", properties: ["result":"success"])
+            SEGAnalytics.shared().track("Tinker_PhotonSetupEnded", properties: ["result":"success"])
             
             if let deviceAdded = device
             {
@@ -597,7 +597,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
         {
             ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Photon setup cancelled or failed.", withParameters: getVaList([]))
 
-            SEGAnalytics.shared().track("Photon setup ended", properties: ["result":"cancelled or failed"])
+            SEGAnalytics.shared().track("Tinker_PhotonSetupEnded", properties: ["result":"cancelled or failed"])
             RMessage.showNotification(withTitle: "Warning", subtitle: "Device setup did not complete.", type: .warning, customTypeName: nil, callback: nil)
         }
     }
@@ -642,7 +642,7 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
         self.customizeSetupForSetupFlow()
         if let vc = ParticleSetupMainController(setupOnly: !ParticleCloud.sharedInstance().isAuthenticated)
         {
-            SEGAnalytics.shared().track("Tinker: Photon setup invoked")
+            SEGAnalytics.shared().track("Tinker_PhotonSetupInvoked")
             vc.delegate = self
             self.present(vc, animated: true, completion: nil)
         }
@@ -652,13 +652,13 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
     
     func showParticleCoreAppPopUp()
     {
-        SEGAnalytics.shared().track("Tinker: User wants to setup a Core")
+        SEGAnalytics.shared().track("Tinker_UserWantsToSetupACore")
         
         let dialog = ZAlertView(title: "Core setup", message: "Setting up a Core requires the legacy Particle Core app. Do you want to install/open it now?", isOkButtonLeft: true, okButtonText: "Yes", cancelButtonText: "No",
                                 okButtonHandler: { alertView in
                                     alertView.dismiss()
                                     let particleCoreAppStoreLink = "itms://itunes.apple.com/us/app/apple-store/id760157884?mt=8";
-                                    SEGAnalytics.shared().track("Tinker: Send user to old Particle Core app")
+                                    SEGAnalytics.shared().track("Tinker_SendUserToOldParticleCoreApp")
                                     UIApplication.shared.openURL(URL(string: particleCoreAppStoreLink)!)
                                     
             },

--- a/Photon-Tinker/DeviceListViewController.swift
+++ b/Photon-Tinker/DeviceListViewController.swift
@@ -681,8 +681,6 @@ class DeviceListViewController: UIViewController, UITableViewDelegate, UITableVi
         tableView.deselectRow(at: indexPath, animated: true)
         let device = self.devices[(indexPath as NSIndexPath).row]
 
-        ParticleLogger.logInfo(NSStringFromClass(type(of: self)), format: "Selected device: %@", withParameters: getVaList([device]))
-
         tableView.deselectRow(at: indexPath, animated: false)
         
         //                println("Tapped on \(self.devices[indexPath.row].description)")

--- a/Photon-Tinker/DeviceVariableTableViewCell.swift
+++ b/Photon-Tinker/DeviceVariableTableViewCell.swift
@@ -57,7 +57,7 @@ internal class DeviceVariableTableViewCell: DeviceDataTableViewCell {
 
         
         self.activityIndicator.startAnimating()
-        SEGAnalytics.shared().track("Device Inspector: variable read")
+        SEGAnalytics.shared().track("DeviceInspector_VariableRead")
         self.resultLabel.isHidden = true
         self.device?.getVariable(variableName!, completion: { (resultObj:Any?, error:Error?) in
             

--- a/Photon-Tinker/ElectronSetupViewController.swift
+++ b/Photon-Tinker/ElectronSetupViewController.swift
@@ -236,12 +236,12 @@ class ElectronSetupViewController: UIViewController, UIWebViewDelegate, ScanBarc
         let actionType = request.url?.host;
 //        let jsonDictString = request.URL?.fragment?.stringByReplacingPercentEscapesUsingEncoding(NSASCIIStringEncoding)
         if actionType == "scanIccid" {
-            SEGAnalytics.shared().track("Tinker: Electron setup scan ICCID")
+            SEGAnalytics.shared().track("Tinker_ElectronSetupScanICCID")
             self.performSegue(withIdentifier: "scan", sender: self)
         } else if actionType == "scanCreditCard" {
             print("Scan credit card requested.. not implemented yet")
         } else if actionType == "done" {
-            SEGAnalytics.shared().track("Tinker: Electron setup ended", properties: ["result":"success"])
+            SEGAnalytics.shared().track("Tinker_ElectronSetupEnded", properties: ["result":"success"])
             self.dismiss(animated: true, completion: nil)
         } else if actionType == "notification" {
 //            print("\(request.URL)")

--- a/Photon-Tinker/HelpViewController.swift
+++ b/Photon-Tinker/HelpViewController.swift
@@ -144,7 +144,7 @@ class HelpViewController: UIViewController, UITableViewDelegate, UITableViewData
         switch (indexPath as NSIndexPath).section
         {
         case 0: // docs
-            SEGAnalytics.shared().track("Tinker: Go to documentation")
+            SEGAnalytics.shared().track("Tinker_GoToDocumentation")
 
             
             switch (indexPath as NSIndexPath).row
@@ -165,7 +165,7 @@ class HelpViewController: UIViewController, UITableViewDelegate, UITableViewData
         
             
         case 1: // Support
-            SEGAnalytics.shared().track("Tinker: Go to support")
+            SEGAnalytics.shared().track("Tinker_GoToSupport")
 
             switch (indexPath as NSIndexPath).row
             {
@@ -181,7 +181,7 @@ class HelpViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             
         default:
-            SEGAnalytics.shared().track("Tinker: Tutorials reset")
+            SEGAnalytics.shared().track("Tinker_TutorialsReset")
             ParticleUtils.resetTutorialWasDisplayed()
             DispatchQueue.main.async {
                 RMessage.showNotification(withTitle: "Tutorials reset", subtitle: "App tutorials will now be displayed once again", type: .success, customTypeName: nil, callback: nil)

--- a/Photon-Tinker/ParticleUtils.swift
+++ b/Photon-Tinker/ParticleUtils.swift
@@ -20,6 +20,11 @@ class ParticleUtils: NSObject {
     static var particleRegularFont = UIFont(name: "Gotham-book", size: 16.0)!
     static var particleBoldFont = UIFont(name: "Gotham-medium", size: 16.0)!
 
+    private static let randomNames = ["aardvark", "bacon", "badger", "banjo", "bobcat", "boomer", "captain", "chicken", "cowboy", "maker", "splendid", "sparkling", "dentist", "doctor", "green", "easter", "ferret", "gerbil", "hacker", "hamster", "wizard", "hobbit", "hoosier", "hunter", "jester", "jetpack", "kitty", "laser", "lawyer", "mighty", "monkey", "morphing", "mutant", "narwhal", "ninja", "normal", "penguin", "pirate", "pizza", "plumber", "power", "puppy", "ranger", "raptor", "robot", "scraper", "burrito", "station", "tasty", "trochee", "turkey", "turtle", "vampire", "wombat", "zombie"]
+    class func getRandomDeviceName() -> String {
+        return "\(randomNames.randomElement()!)_\(randomNames.randomElement()!)"
+    }
+
     class func getDeviceTypeAndImage(_ device : ParticleDevice?) -> (deviceType: String, deviceImage: UIImage) {
         
         

--- a/Photon-Tinker/SPKTinkerViewController.m
+++ b/Photon-Tinker/SPKTinkerViewController.m
@@ -106,7 +106,7 @@
     // animate the deviceStateIndicatorImageView
     [ParticleUtils animateOnlineIndicatorImageView:self.deviceStateIndicatorImageView online:self.device.connected flashing:self.device.isFlashing];
     
-    [[SEGAnalytics sharedAnalytics] track:@"Tinker: Tinker screen activity"];
+    [[SEGAnalytics sharedAnalytics] track:@"Tinker_TinkerScreenActivity"];
     if (self.chipView.alpha == 0)
         [ParticleSpinner show:self.view];
 }
@@ -114,7 +114,7 @@
 -(void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [[SEGAnalytics sharedAnalytics] track:@"Tinker: Tinker screen activity"];
+    [[SEGAnalytics sharedAnalytics] track:@"Tinker_TinkerScreenActivity"];
 }
 
 
@@ -576,7 +576,7 @@
             if (pinView.pin.selectedFunction == DevicePinFunctionDigitalWrite || pinView.pin.selectedFunction == DevicePinFunctionAnalogWrite || pinView.pin.selectedFunction == DevicePinFunctionAnalogWriteDAC) {
                 if (result < 0) {
 
-                    [[SEGAnalytics sharedAnalytics] track:@"Tinker: error" properties:@{@"type":@"pin write"}];
+                    [[SEGAnalytics sharedAnalytics] track:@"Tinker_Error" properties:@{@"type":@"pin write"}];
 
                     [RMessage showNotificationWithTitle:@"Device pin error" subtitle:@"There was a problem writing to this pin." type:RMessageTypeError customTypeName:nil callback:nil];
                     [pinView.pin resetValue];
@@ -595,7 +595,7 @@
             [pinView endUpdating];
             
             NSString* errorStr = [NSString stringWithFormat:@"Error communicating with device (%@)",errorMessage];
-            [[SEGAnalytics sharedAnalytics] track:@"Tinker: error" properties:@{@"type":@"communicate with device"}];
+            [[SEGAnalytics sharedAnalytics] track:@"Tinker_Error" properties:@{@"type":@"communicate with device"}];
 
             [RMessage showNotificationWithTitle:@"Device error" subtitle:errorStr type:RMessageTypeError customTypeName:nil callback:nil];
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,12 +45,12 @@ PODS:
     - nanopb/encode (= 0.3.8)
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
-  - Particle-SDK (0.9.3):
-    - Particle-SDK/Helpers (= 0.9.3)
-    - Particle-SDK/SDK (= 0.9.3)
-  - Particle-SDK/Helpers (0.9.3):
+  - Particle-SDK (0.9.4):
+    - Particle-SDK/Helpers (= 0.9.4)
+    - Particle-SDK/SDK (= 0.9.4)
+  - Particle-SDK/Helpers (0.9.4):
     - AFNetworking (~> 3.0)
-  - Particle-SDK/SDK (0.9.3):
+  - Particle-SDK/SDK (0.9.4):
     - AFNetworking (~> 3.0)
     - Particle-SDK/Helpers
   - ParticleSetup (0.9.0):
@@ -141,7 +141,7 @@ SPEC CHECKSUMS:
   IQKeyboardManager: 29514134ef0334a6fa33cf4eee11c36c064baeaf
   MBProgressHUD: 1569cf7ace17a8bac47aabfbb8580a49690386d1
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
-  Particle-SDK: c42131aac8c00fd6a9ad3620ca9a5e755f6f1898
+  Particle-SDK: b50cdf6172eaf3e29338b81d6e8157350e7f4c11
   ParticleSetup: 8a0b767d26c5c5d355f8b9929ba2d65a3a498313
   PPTopMostController: 4e6f1e5f8c645bdcc74cd837a20f607ff262c048
   PullToRefreshCoreText: c843e71fc5ae5b033c0281067368905efd05c7b2


### PR DESCRIPTION
This PR updates app to work with 0.9.4 SDK version that stopped getting full device info for every device that reports itself online just by hitting getDevices endpoint.

Also all event names for analytics have been renamed to work with firebase which forbids colon (:) sign.