### PR TITLE
Feature/no mesh setup

### DIFF
--- a/Photon-Tinker/Mesh/Common/MeshSetupFlowUIBase.swift
+++ b/Photon-Tinker/Mesh/Common/MeshSetupFlowUIBase.swift
@@ -378,6 +378,7 @@ class MeshSetupUIBase : UIViewController, Storyboardable, MeshSetupFlowRunnerDel
             if (!self.rewindTo(MeshSetupPricingInfoViewController.self)) {
                 let pricingInfoVC = MeshSetupPricingInfoViewController.loadedViewController()
                 pricingInfoVC.ownerStepType = self.currentStepType
+                pricingInfoVC.allowBack = self.flowRunner.context.targetDevice.supportsMesh
                 pricingInfoVC.setup(didPressContinue: self.pricingInfoViewCompleted, pricingInfo: info)
                 self.embededNavigationController.pushViewController(pricingInfoVC, animated: true)
             }

--- a/Photon-Tinker/Mesh/ControlPanel/MeshSetupControlPanelUIManager.swift
+++ b/Photon-Tinker/Mesh/ControlPanel/MeshSetupControlPanelUIManager.swift
@@ -537,11 +537,10 @@ class MeshSetupControlPanelUIManager: MeshSetupUIBase {
     }
 
     internal func showMeshNotSupported() {
-        //TODO: fix copy
         DispatchQueue.main.async {
             if (self.hideAlertIfVisible()) {
                 self.alert = UIAlertController(title: MeshStrings.Prompt.ErrorTitle,
-                        message: MeshStrings.Prompt.ControlPanelExternalSimNotSupportedText,
+                        message: MeshStrings.Prompt.ControlPanelMeshNotSupportedText,
                         preferredStyle: .alert)
 
                 self.alert!.addAction(UIAlertAction(title: MeshStrings.Action.Ok, style: .default) { action in

--- a/Photon-Tinker/Mesh/ControlPanel/MeshSetupControlPanelUIManager.swift
+++ b/Photon-Tinker/Mesh/ControlPanel/MeshSetupControlPanelUIManager.swift
@@ -536,6 +536,23 @@ class MeshSetupControlPanelUIManager: MeshSetupUIBase {
         }
     }
 
+    internal func showMeshNotSupported() {
+        //TODO: fix copy
+        DispatchQueue.main.async {
+            if (self.hideAlertIfVisible()) {
+                self.alert = UIAlertController(title: MeshStrings.Prompt.ErrorTitle,
+                        message: MeshStrings.Prompt.ControlPanelExternalSimNotSupportedText,
+                        preferredStyle: .alert)
+
+                self.alert!.addAction(UIAlertAction(title: MeshStrings.Action.Ok, style: .default) { action in
+                    (self.embededNavigationController.topViewController as? MeshSetupViewController)?.resume(animated: true)
+                })
+
+                self.present(self.alert!, animated: true)
+            }
+        }
+    }
+
     override func meshSetupDidEnterState(_ sender: MeshSetupStep, state: MeshSetupFlowState) {
         super.meshSetupDidEnterState(sender, state: state)
 
@@ -557,6 +574,9 @@ class MeshSetupControlPanelUIManager: MeshSetupUIBase {
         } else if (error == .ExternalSimNotSupported) {
             self.controlPanelManager.stopCurrentFlow()
             self.showExternalSim()
+        } else if (error == .MeshNotSupported) {
+            self.controlPanelManager.stopCurrentFlow()
+            self.showMeshNotSupported()
         } else {
             super.meshSetupError(sender, error: error, severity: severity, nsError: nsError)
         }

--- a/Photon-Tinker/Mesh/MeshSetupDevice.swift
+++ b/Photon-Tinker/Mesh/MeshSetupDevice.swift
@@ -29,6 +29,7 @@ internal struct MeshSetupDevice {
     var ncpModuleVersion: Int?
     var ncpVersionReceived: Bool?
     var supportsCompressedOTAUpdate: Bool?
+    var supportsMesh: Bool = false
 
     var firmwareFilesFlashed: Int?
     var firmwareUpdateProgress: Double?

--- a/Photon-Tinker/Mesh/MeshSetupError.swift
+++ b/Photon-Tinker/Mesh/MeshSetupError.swift
@@ -34,6 +34,7 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
     case BluetoothConnectionDropped
 
     case MeshNotSupported
+    case CommissionerMeshNotSupported
 
     //Can happen in any step, when result != NONE and special case is not handled by onReply handler
     case BluetoothError
@@ -111,6 +112,7 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
 
                 //TODO: add copy
             case .MeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
+            case .CommissionerMeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
 
 
                 //these errors are handled instantly

--- a/Photon-Tinker/Mesh/MeshSetupError.swift
+++ b/Photon-Tinker/Mesh/MeshSetupError.swift
@@ -110,8 +110,8 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
             case .FailedToFlashBecauseOfTimeout : return MeshStrings.Error.FailedToFlashBecauseOfTimeout.meshLocalized()
             case .FailedToHandshakeBecauseOfTimeout : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
 
-            case .MeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
-            case .CommissionerMeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
+            case .MeshNotSupported : return MeshStrings.Error.MeshNotSupported.meshLocalized()
+            case .CommissionerMeshNotSupported : return MeshStrings.Error.CommissionerMeshNotSupported.meshLocalized()
 
                 //these errors are handled instantly
             case .FailedToUpdateDeviceOS : return MeshStrings.Error.FailedToUpdateDeviceOS.meshLocalized()

--- a/Photon-Tinker/Mesh/MeshSetupError.swift
+++ b/Photon-Tinker/Mesh/MeshSetupError.swift
@@ -110,10 +110,8 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
             case .FailedToFlashBecauseOfTimeout : return MeshStrings.Error.FailedToFlashBecauseOfTimeout.meshLocalized()
             case .FailedToHandshakeBecauseOfTimeout : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
 
-                //TODO: add copy
             case .MeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
             case .CommissionerMeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
-
 
                 //these errors are handled instantly
             case .FailedToUpdateDeviceOS : return MeshStrings.Error.FailedToUpdateDeviceOS.meshLocalized()

--- a/Photon-Tinker/Mesh/MeshSetupError.swift
+++ b/Photon-Tinker/Mesh/MeshSetupError.swift
@@ -33,6 +33,8 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
     case BluetoothDisabled
     case BluetoothConnectionDropped
 
+    case MeshNotSupported
+
     //Can happen in any step, when result != NONE and special case is not handled by onReply handler
     case BluetoothError
     case BluetoothTimeout
@@ -106,6 +108,9 @@ enum MeshSetupFlowError: Error, CustomStringConvertible {
             case .FailedToGetDeviceInfo : return MeshStrings.Error.FailedToGetDeviceInfo.meshLocalized()
             case .FailedToFlashBecauseOfTimeout : return MeshStrings.Error.FailedToFlashBecauseOfTimeout.meshLocalized()
             case .FailedToHandshakeBecauseOfTimeout : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
+
+                //TODO: add copy
+            case .MeshNotSupported : return MeshStrings.Error.FailedToHandshakeBecauseOfTimeout.meshLocalized()
 
 
                 //these errors are handled instantly

--- a/Photon-Tinker/Mesh/MeshSetupFlowManager.swift
+++ b/Photon-Tinker/Mesh/MeshSetupFlowManager.swift
@@ -13,12 +13,12 @@ class MeshSetupFlowManager : MeshSetupFlowRunner {
         StepConnectToTargetDevice(),
         StepEnsureCorrectEthernetFeatureStatus(),
         StepEnsureLatestFirmware(),
+        StepCheckHasNetworkInterfaces(),
         StepGetAPINetworks(),
         StepEnsureCanBeClaimed(),
         StepSetClaimCode(),
         StepOfferToSwitchToControlPanel(),
         StepEnsureNotOnMeshNetwork(),
-        StepCheckHasNetworkInterfaces(),
     ]
 
     fileprivate let joinerFlow: [MeshSetupStep] = [

--- a/Photon-Tinker/Mesh/MeshSetupFlowManager.swift
+++ b/Photon-Tinker/Mesh/MeshSetupFlowManager.swift
@@ -141,12 +141,11 @@ class MeshSetupFlowManager : MeshSetupFlowRunner {
                 "Switching flow!!!")
 
         if (currentFlow == preflow) {
-            if (context.targetDevice.hasActiveInternetInterface() && context.selectedNetworkMeshInfo == nil) {
+            if ((context.targetDevice.hasActiveInternetInterface() && context.selectedNetworkMeshInfo == nil) || !context.targetDevice.supportsMesh) {
                 self.currentFlow = internetConnectedPreflow
                 log("setting gateway flow")
             } else {
                 //if context.targetDevice.hasActiveInternetInterface() == argon/boron/ethernet joiner flow
-
                 log("setting xenon joiner flow")
                 self.currentFlow = joinerFlow
             }

--- a/Photon-Tinker/Mesh/MeshSetupFlowUIManager.swift
+++ b/Photon-Tinker/Mesh/MeshSetupFlowUIManager.swift
@@ -157,6 +157,7 @@ class MeshSetupFlowUIManager : MeshSetupUIBase {
     override func meshSetupDidRequestToSwitchToControlPanel(_ sender: MeshSetupStep, device: ParticleDevice) {
         currentStepType = type(of: sender)
 
+        //TODO: drop commissioner connection
         DispatchQueue.main.async {
             if (self.hideAlertIfVisible()) {
                 self.alert = UIAlertController(title: MeshStrings.Prompt.SwitchToControlPanelTitle, message: MeshStrings.Prompt.SwitchToControlPanelText, preferredStyle: .alert)

--- a/Photon-Tinker/Mesh/MeshSetupProtocolTransceiver.swift
+++ b/Photon-Tinker/Mesh/MeshSetupProtocolTransceiver.swift
@@ -37,7 +37,7 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
         }
     }
 
-    private unowned var bluetoothConnection: MeshSetupBluetoothConnection
+    private weak var bluetoothConnection: MeshSetupBluetoothConnection?
     private var encryptionManager: MeshSetupEncryptionManager
 
     private var requestMessageId: UInt16 = 1
@@ -48,7 +48,7 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
     private var rxBuffer: Data = Data()
 
 
-    var connection: MeshSetupBluetoothConnection {
+    var connection: MeshSetupBluetoothConnection? {
         get {
             return bluetoothConnection
         }
@@ -69,11 +69,11 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
 
     required init(connection: MeshSetupBluetoothConnection) {
         self.bluetoothConnection = connection
-        self.encryptionManager = MeshSetupEncryptionManager(derivedSecret: bluetoothConnection.derivedSecret!)
+        self.encryptionManager = MeshSetupEncryptionManager(derivedSecret: bluetoothConnection!.derivedSecret!)
 
         super.init()
 
-        self.bluetoothConnection.dataDelegate = self // take over didReceiveData delegate
+        self.bluetoothConnection!.dataDelegate = self // take over didReceiveData delegate
     }
 
     private func log(_ message: String) {
@@ -98,7 +98,7 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
     }
 
     private func sendRequestMessage(data: (UInt16, Data), onReply: @escaping (ReplyMessage?) -> ()) {
-        if (self.bluetoothConnection.cbPeripheral.state == .disconnected || self.bluetoothConnection.cbPeripheral.state == .disconnecting) {
+        if (self.bluetoothConnection == nil || self.bluetoothConnection!.cbPeripheral.state == .disconnected || self.bluetoothConnection!.cbPeripheral.state == .disconnecting) {
             self.requestMessageId -= 1 //to avoid message idx getting out of sync with device
             onReply(nil)
             return
@@ -109,7 +109,7 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
     }
 
     private func sendOTARequestMessage(data: (UInt16, Data), onReply: @escaping (ReplyMessage?) -> ()) {
-        if (self.bluetoothConnection.cbPeripheral.state == .disconnected || self.bluetoothConnection.cbPeripheral.state == .disconnecting) {
+        if (self.bluetoothConnection == nil || self.bluetoothConnection!.cbPeripheral.state == .disconnected || self.bluetoothConnection!.cbPeripheral.state == .disconnecting) {
             self.requestMessageId -= 1 //to avoid message idx getting out of sync with device
             onReply(nil)
             return
@@ -124,7 +124,7 @@ class MeshSetupProtocolTransceiver: NSObject, MeshSetupBluetoothConnectionDataDe
             self.waitingForReply = true
             let message = self.pendingMessages.first!
             log("Sending message: \(message.messageId)")
-            self.bluetoothConnection.send(data: message.data, writeType: message.writeWithResponse ? .withResponse : .withoutResponse)
+            self.bluetoothConnection?.send(data: message.data, writeType: message.writeWithResponse ? .withResponse : .withoutResponse)
         }
     }
 

--- a/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
+++ b/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
@@ -63,9 +63,9 @@ class StepCheckHasNetworkInterfaces: MeshSetupStep {
                 context.targetDevice.networkInterfaces = interfaces!
 
                 for interface in interfaces! {
-//                    if (interface.type == .thread) {
-//                        context.targetDevice.supportsMesh = true
-//                    }
+                    if (interface.type == .thread) {
+                        context.targetDevice.supportsMesh = true
+                    }
 
                     if (interface.type == .ethernet) {
                         //top priority

--- a/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
+++ b/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
@@ -63,6 +63,10 @@ class StepCheckHasNetworkInterfaces: MeshSetupStep {
                 context.targetDevice.networkInterfaces = interfaces!
 
                 for interface in interfaces! {
+                    if (interface.type == .thread) {
+                        context.targetDevice.supportsMesh = true
+                    }
+
                     if (interface.type == .ethernet) {
                         //top priority
                         context.targetDevice.activeInternetInterface = .ethernet

--- a/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
+++ b/Photon-Tinker/Mesh/StepCheckHasNetworkInterfaces.swift
@@ -63,9 +63,9 @@ class StepCheckHasNetworkInterfaces: MeshSetupStep {
                 context.targetDevice.networkInterfaces = interfaces!
 
                 for interface in interfaces! {
-                    if (interface.type == .thread) {
-                        context.targetDevice.supportsMesh = true
-                    }
+//                    if (interface.type == .thread) {
+//                        context.targetDevice.supportsMesh = true
+//                    }
 
                     if (interface.type == .ethernet) {
                         //top priority

--- a/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
+++ b/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
+    private var expectingConnectionDrop: Bool = false
+
     override func start() {
         guard let context = self.context else {
             return
@@ -19,7 +21,7 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
             self.log("commissionerDevice.sendGetNetworkInfo: \(result.description()), networkInfo: \(networkInfo as Optional)")
 
 
-            if (result == .NOT_FOUND) {
+            if (result == .NOT_FOUND || result == .NOT_SUPPORTED) {
                 context.commissionerDevice!.meshNetworkInfo = nil
             } else if (result == .NONE) {
                 context.commissionerDevice!.meshNetworkInfo = networkInfo
@@ -57,6 +59,17 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
         }
     }
 
+    override func handleBluetoothConnectionManagerConnectionDropped(_ connection: MeshSetupBluetoothConnection) -> Bool {
+        //this is expected
+        return expectingConnectionDrop
+    }
+
+    override func reset() {
+        super.reset()
+
+        self.expectingConnectionDrop = false
+    }
+
     override func rewindTo(context: MeshSetupContext) {
         super.rewindTo(context: context)
 
@@ -64,6 +77,7 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
             return
         }
 
+        expectingConnectionDrop = false
         context.commissionerDevice?.meshNetworkInfo = nil
     }
 }

--- a/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
+++ b/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
@@ -48,10 +48,12 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
                 }
 
                 //drop connection with current peripheral
-                let connection = context.commissionerDevice!.transceiver!.connection
-                context.commissionerDevice!.transceiver = nil
-                context.commissionerDevice = nil
-                context.bluetoothManager.dropConnection(with: connection)
+
+                if let connection = context.commissionerDevice!.transceiver!.connection {
+                    context.commissionerDevice!.transceiver = nil
+                    context.commissionerDevice = nil
+                    context.bluetoothManager.dropConnection(with: connection)
+                }
 
                 let _ = context.stepDelegate.rewindTo(self, step: StepGetCommissionerDeviceInfo.self, runStep: true)
                 context.paused = false

--- a/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
+++ b/Photon-Tinker/Mesh/StepEnsureCommissionerNetworkMatches.swift
@@ -18,6 +18,7 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
 
             self.log("commissionerDevice.sendGetNetworkInfo: \(result.description()), networkInfo: \(networkInfo as Optional)")
 
+
             if (result == .NOT_FOUND) {
                 context.commissionerDevice!.meshNetworkInfo = nil
             } else if (result == .NONE) {
@@ -38,7 +39,11 @@ class StepEnsureCommissionerNetworkMatches : MeshSetupStep {
                     return
                 }
             } else {
-                self.fail(withReason: .CommissionerNetworkDoesNotMatch)
+                if result == .NOT_SUPPORTED  {
+                    self.fail(withReason: .CommissionerMeshNotSupported)
+                } else {
+                    self.fail(withReason: .CommissionerNetworkDoesNotMatch)
+                }
 
                 //drop connection with current peripheral
                 let connection = context.commissionerDevice!.transceiver!.connection

--- a/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
+++ b/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
@@ -23,6 +23,11 @@ class StepEnsureNotOnMeshNetwork: MeshSetupStep {
             return
         }
 
+        guard context.targetDevice.supportsMesh == false else {
+            self.stepCompleted()
+            return
+        }
+
         if (!meshNetworkInfoLoaded) {
             self.getTargetDeviceMeshNetworkInfo()
         } else if (context.userSelectedToLeaveNetwork == nil) {
@@ -52,6 +57,12 @@ class StepEnsureNotOnMeshNetwork: MeshSetupStep {
 
             self.log("targetDevice.sendGetNetworkInfo: \(result.description())")
             self.log("\(networkInfo as Optional)");
+
+            guard result != .NOT_SUPPORTED else {
+                context.targetDevice.supportsMesh = false
+                self.stepCompleted()
+                return
+            }
 
             if (result == .NOT_FOUND) {
                 self.meshNetworkInfoLoaded = true

--- a/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
+++ b/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
@@ -60,6 +60,7 @@ class StepEnsureNotOnMeshNetwork: MeshSetupStep {
 
             guard result != .NOT_SUPPORTED else {
                 context.targetDevice.supportsMesh = false
+                context.targetDevice.meshNetworkInfo = nil
                 self.stepCompleted()
                 return
             }

--- a/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
+++ b/Photon-Tinker/Mesh/StepEnsureNotOnMeshNetwork.swift
@@ -23,7 +23,7 @@ class StepEnsureNotOnMeshNetwork: MeshSetupStep {
             return
         }
 
-        guard context.targetDevice.supportsMesh == false else {
+        guard context.targetDevice.supportsMesh else {
             self.stepCompleted()
             return
         }

--- a/Photon-Tinker/Mesh/StepFinishJoinSelectedNetwork.swift
+++ b/Photon-Tinker/Mesh/StepFinishJoinSelectedNetwork.swift
@@ -114,10 +114,11 @@ class StepFinishJoinSelectedNetwork: MeshSetupStep {
             return
         }
 
-        let connection = context.commissionerDevice!.transceiver!.connection
-        context.commissionerDevice!.transceiver = nil
-        context.commissionerDevice = nil
-        context.bluetoothManager.dropConnection(with: connection)
+        if let connection = context.commissionerDevice!.transceiver!.connection {
+            context.commissionerDevice!.transceiver = nil
+            context.commissionerDevice = nil
+            context.bluetoothManager.dropConnection(with: connection)
+        }
 
         self.start()
     }

--- a/Photon-Tinker/Mesh/StepGetAPINetworks.swift
+++ b/Photon-Tinker/Mesh/StepGetAPINetworks.swift
@@ -12,6 +12,11 @@ class StepGetAPINetworks: MeshSetupStep {
             return
         }
 
+        guard context.targetDevice.supportsMesh == false else {
+            self.stepCompleted()
+            return
+        }
+
         ParticleCloud.sharedInstance().getNetworks { [weak self, weak context] networks, error in
             guard let self = self, let context = context, !context.canceled else {
                 return

--- a/Photon-Tinker/Mesh/StepGetAPINetworks.swift
+++ b/Photon-Tinker/Mesh/StepGetAPINetworks.swift
@@ -12,7 +12,7 @@ class StepGetAPINetworks: MeshSetupStep {
             return
         }
 
-        guard context.targetDevice.supportsMesh == false else {
+        guard context.targetDevice.supportsMesh else {
             self.stepCompleted()
             return
         }

--- a/Photon-Tinker/Mesh/StepGetMeshNetwork.swift
+++ b/Photon-Tinker/Mesh/StepGetMeshNetwork.swift
@@ -19,6 +19,11 @@ class StepGetMeshNetwork: MeshSetupStep {
             return
         }
 
+        guard context.targetDevice.supportsMesh == false else {
+            self.fail(withReason: .MeshNotSupported)
+            return
+        }
+
         if (context.targetDevice.meshNetworkInfo == nil && !meshNetworkInfoLoaded) {
             self.getTargetDeviceMeshNetworkInfo()
         } else if (context.apiNetworks == nil && !apiNetworksLoaded) {
@@ -37,6 +42,12 @@ class StepGetMeshNetwork: MeshSetupStep {
 
             self.log("targetDevice.sendGetNetworkInfo: \(result.description())")
             self.log("\(networkInfo as Optional)");
+
+            guard result != .NOT_SUPPORTED else {
+                self.context?.targetDevice.supportsMesh = false
+                self.fail(withReason: .MeshNotSupported)
+                return
+            }
 
             if (result == .NOT_FOUND) {
                 self.meshNetworkInfoLoaded = true

--- a/Photon-Tinker/Mesh/StepGetMeshNetwork.swift
+++ b/Photon-Tinker/Mesh/StepGetMeshNetwork.swift
@@ -19,7 +19,7 @@ class StepGetMeshNetwork: MeshSetupStep {
             return
         }
 
-        guard context.targetDevice.supportsMesh == false else {
+        guard context.targetDevice.supportsMesh else {
             self.fail(withReason: .MeshNotSupported)
             return
         }

--- a/Photon-Tinker/Mesh/StepOfferSetupStandAloneOrWithNetwork.swift
+++ b/Photon-Tinker/Mesh/StepOfferSetupStandAloneOrWithNetwork.swift
@@ -11,7 +11,13 @@ class StepOfferSetupStandAloneOrWithNetwork : MeshSetupStep {
             return
         }
 
-       context.delegate.meshSetupDidRequestToSelectStandAloneOrMeshSetup(self)
+        guard context.targetDevice.supportsMesh else {
+            context.userSelectedToSetupMesh = false
+            self.stepCompleted()
+            return
+        }
+
+        context.delegate.meshSetupDidRequestToSelectStandAloneOrMeshSetup(self)
     }
 
     func setSelectStandAloneOrMeshSetup(meshSetup: Bool) -> MeshSetupFlowError? {

--- a/Photon-Tinker/Mesh/StepOfferToAddOneMoreDevice.swift
+++ b/Photon-Tinker/Mesh/StepOfferToAddOneMoreDevice.swift
@@ -16,9 +16,10 @@ class StepOfferToAddOneMoreDevice : MeshSetupStep {
         if (context.targetDevice.transceiver != nil) {
             self.log("Dropping connection to target device")
 
-            let connection = context.targetDevice.transceiver!.connection
-            context.targetDevice.transceiver = nil
-            context.bluetoothManager.dropConnection(with: connection)
+            if let connection = context.targetDevice.transceiver!.connection {
+                context.targetDevice.transceiver = nil
+                context.bluetoothManager.dropConnection(with: connection)
+            }
         }
 
         context.delegate.meshSetupDidRequestToAddOneMoreDevice(self)


### PR DESCRIPTION
This PR adds support for setting up devices running Device OS v2.0 or greater that will no longer support mesh. The code relies on the assumption that Thread network will be removed from network interfaces returned by Device OS and that all mesh related control requests will return `NOT_SUPPORTED` error response.